### PR TITLE
fixing up facilitator profiles

### DIFF
--- a/amber_lim.yml
+++ b/amber_lim.yml
@@ -2,6 +2,7 @@ name: Amber Lim
 title: Research Computing Facilitator
 institution: "University of Wisconsin–Madison"
 is_facilitator: 1
+weight: 5
 status: Staff
 organizations: 
   - chtc

--- a/andrew_owen.yml
+++ b/andrew_owen.yml
@@ -3,6 +3,7 @@ institution: University of Wisconsin-Madison
 title: Research Computing Facilitator
 is_facilitator: 1
 name: Andrew Owen
+weight: 5
 status: Staff
 website: null
 organizations: 

--- a/christina_koch.yml
+++ b/christina_koch.yml
@@ -8,7 +8,7 @@ website: https://www.cs.wisc.edu/staff/koch-christina/
 is_facilitator: 1
 status: Staff
 linkedinurl: ""
-weight: 5
+weight: 6
 chtc:
     title: Lead Research Computing Facilitator
 pelican:

--- a/danny_morales.yml
+++ b/danny_morales.yml
@@ -3,6 +3,7 @@ image: "images/danny_morales.jpg"
 title: "Research Computing Facilitator"
 institution: "University of Wisconsin - Madison"
 is_facilitator: 1
+weight: 5
 status: Staff
 organizations: 
     - path

--- a/mats_rynge.yml
+++ b/mats_rynge.yml
@@ -5,6 +5,7 @@ draft: false
 image: "images/mats_rynge.jpg"
 title: "Systems Integrator"
 institution: "University of Southern California - Information Sciences Institute"
+is_facilitator: 1
 #website: ""
 linkedinurl: ""
 weight: 5

--- a/showmic_islam.yml
+++ b/showmic_islam.yml
@@ -3,6 +3,7 @@ image: "images/showmic_islam.jpg"
 title: "Research Facilitator"
 #website: ""
 institution: "University of Nebraska-Lincoln"
+is_facilitator: 1
 weight: 5
 organizations: 
     - path


### PR DESCRIPTION
Added `is_facilitator` to Mats + Showmic, added weights to other CHTC RCFs, increased Christina's weight. Not sure if that was the right thing to do. We need some mechanism so that my profile is first...

Will need to edit CHTC RCF page to make sure we filter for just CHTC RCFs before this is merged. 
(https://github.com/CHTC/chtc-website-source/issues/878)