### PR TITLE
Add status to parker_harding.yml

### DIFF
--- a/parker_harding.yml
+++ b/parker_harding.yml
@@ -3,5 +3,6 @@ image: "images/parker_harding.jpg"
 title: "Associate IT Professional"
 website: "www.linkedin.com/in/parker-harding-1924381b6"
 institution: "University of Wisconsin-Madison"
+status: "Staff"
 organizations:
   - chtc


### PR DESCRIPTION
Add 'status: "Staff"' to parker_harding.yml within init-staff-list so that my profile would appear on the website in the proper place